### PR TITLE
 Byte array data wasn't being returned correctly

### DIFF
--- a/lib/googlestaticmap.rb
+++ b/lib/googlestaticmap.rb
@@ -172,12 +172,12 @@ class GoogleStaticMap
     http = Net::HTTP.Proxy(@proxy_address,@proxy_port).new("maps.google.com", port)
     http.use_ssl = protocol == 'https'
 
-    resp, data = http.get2(relative_url(protocol))
+    resp = http.get2(relative_url(protocol))
     if resp && resp.is_a?(Net::HTTPSuccess)
       if output_file
-        File.open(output_file, "wb") {|f| f << data }
+        File.open(output_file, "wb") {|f| f << resp.body }
       end
-      data
+      resp.body
     else
       if resp
         raise Exception.new("Error encountered while retrieving google map, code #{resp.code}, text #{resp.body}")


### PR DESCRIPTION
At least not with ruby 1.9.3. The Net::HTTP.get2 method signature seems to have changed which caused the breakage.
