### PR TITLE
escape pipe characters in urls

### DIFF
--- a/lib/googlestaticmap.rb
+++ b/lib/googlestaticmap.rb
@@ -60,6 +60,8 @@ require 'net/http'
 require 'net/https' if RUBY_VERSION < "1.9"
 require File.dirname(__FILE__) +  '/googlestaticmap_helper'
 
+MAP_SEPARATOR = CGI.escape("|")
+
 # Main class for creating a static map.  Create an instance, Set attributes
 # that describe properties of the map.  Then call url to get a URL that you
 # can use as the src of an img tag.  You can also call get_map to actually
@@ -108,7 +110,7 @@ class GoogleStaticMap
   # * terrain
   # * hybrid - satellite imagery with roads
   attr_accessor :maptype
-  
+
   # If you need to use a proxy server to reach Google, set the name/address
   # of the proxy server here
   attr_accessor :proxy_address
@@ -121,7 +123,7 @@ class GoogleStaticMap
     defaults = {:width => 500, :height => 350, :markers => [],
                 :sensor => false, :maptype => "roadmap", :paths => [],
                 :proxy_port => nil, :proxy_address => nil,}
-                
+
     attributes = defaults.merge(attrs)
     attributes.each {|k,v| self.send("#{k}=".to_sym,v)}
   end
@@ -255,8 +257,8 @@ class MapMarker
       # If the icon URL is URL encoded, it won't work
       val = (k[0] == "icon" ? k[1] : CGI.escape(k[1].to_s))
       "#{k[0]}:#{val}"
-    end.join("|")
-    s << "|#{@location.to_s}"
+    end.join(MAP_SEPARATOR)
+    s << MAP_SEPARATOR << @location.to_s
   end
 end
 
@@ -285,8 +287,8 @@ class MapPath
   def to_s
     raise Exception.new("Need more than one point for the path") unless @points && @points.length > 1
     attrs = GoogleStaticMapHelpers.safe_instance_variables(self, ["points"])
-    s = attrs.to_a.collect {|k| "#{k[0]}:#{CGI.escape(k[1].to_s)}"}.join("|")
-    s << "|" << @points.join("|")
+    s = attrs.to_a.collect {|k| "#{k[0]}:#{CGI.escape(k[1].to_s)}"}.join(MAP_SEPARATOR)
+    s << MAP_SEPARATOR << @points.join(MAP_SEPARATOR)
   end
 end
 

--- a/test/tc_google_static_map.rb
+++ b/test/tc_google_static_map.rb
@@ -12,7 +12,7 @@ class MockSuccess < Net::HTTPSuccess #:nodoc: all
 
   def body
     @data
-  end	
+  end
 end
 
 class MockFailure < Net::HTTPServiceUnavailable #:nodoc: all
@@ -68,7 +68,7 @@ class GoogleStaticMapTest < Test::Unit::TestCase #:nodoc: all
     assert u.include?("scale=2")
     assert u.include?("asdf")
     assert u.include?("http://maps.google.com")
-    assert u.include?("color:0x00FF00FF|fillcolor:0x00FF0060|38.8,-77.5|38.8,-76.9|39.2,-76.9|39.2,-77.5|38.8,-77.5"), "Polygon not in URL"
+    assert u.include?("color:0x00FF00FF#{MAP_SEPARATOR}fillcolor:0x00FF0060#{MAP_SEPARATOR}38.8,-77.5#{MAP_SEPARATOR}38.8,-76.9#{MAP_SEPARATOR}39.2,-76.9#{MAP_SEPARATOR}39.2,-77.5#{MAP_SEPARATOR}38.8,-77.5"), "Polygon not in URL"
     assert u.include?("Washington%2C+DC")
 
     f = nil

--- a/test/tc_map_marker.rb
+++ b/test/tc_map_marker.rb
@@ -33,10 +33,15 @@ class MapMarkerTest < Test::Unit::TestCase #:nodoc: all
     m = default_marker
     s = nil
     assert_nothing_raised {s = m.to_s}
-    assert_equal 6, s.split("|").length
+    assert_equal 6, s.split(MAP_SEPARATOR).length
     assert s.include?(CGI.escape("Washington, DC"))
     assert s.include?("color:green")
     assert s.include?("icon:http://www.google.com")
+  end
+
+  def test_string_is_a_valid_ruby_uri
+    m = default_marker
+    URI.parse(m.to_s)
   end
 
   private

--- a/test/tc_map_path_and_polygon.rb
+++ b/test/tc_map_path_and_polygon.rb
@@ -30,10 +30,15 @@ class MapPathAndPolygonTest < Test::Unit::TestCase #:nodoc: all
     p = default_path
     s = nil
     assert_nothing_raised { s = p.to_s }
-    assert_equal 4, s.split("|").length
+    assert_equal 4, s.split(MAP_SEPARATOR).length
     assert s.include?("color:0xFF0000FF")
     assert s.include?("loc1")
     assert s.include?("loc2")
+  end
+
+  def test_string_is_a_valid_ruby_uri
+    m = default_path
+    URI.parse(m.to_s)
   end
 
   def test_polygon


### PR DESCRIPTION
Ruby would give the error `URI::InvalidURIError: bad URI(is not URI?)` when trying to open() or parse the url with pipes that weren't encoded.
