### PR TITLE
Udpate api and client secret logic

### DIFF
--- a/lib/googlestaticmap.rb
+++ b/lib/googlestaticmap.rb
@@ -117,7 +117,7 @@ class GoogleStaticMap
     attrs << ["key", @api_key] if !@api_key.nil?
     attrs << ["client", @client_id] if @api_key.nil? && !@client_id.nil? && !@private_key.nil?
     path << attrs.sort_by {|k,v| k}.collect {|attr| "#{attr[0]}=#{attr[1]}"}.join("&")
-    if (!@api_key.nil? ^ !@client_id.nil?) && !@private_key.nil?
+    if (!@api_key.nil? || !@client_id.nil?) && !@private_key.nil?
       signature = GoogleStaticMapHelpers.sign(path, @private_key)
       path << "&signature=" << signature
     end

--- a/lib/googlestaticmap.rb
+++ b/lib/googlestaticmap.rb
@@ -117,7 +117,7 @@ class GoogleStaticMap
     attrs << ["key", @api_key] if !@api_key.nil?
     attrs << ["client", @client_id] if @api_key.nil? && !@client_id.nil? && !@private_key.nil?
     path << attrs.sort_by {|k,v| k}.collect {|attr| "#{attr[0]}=#{attr[1]}"}.join("&")
-    if @api_key.nil? && !@client_id.nil? && !@private_key.nil?
+    if (!@api_key.nil? ^ !@client_id.nil?) && !@private_key.nil?
       signature = GoogleStaticMapHelpers.sign(path, @private_key)
       path << "&signature=" << signature
     end


### PR DESCRIPTION
Changed logic to validate with an `exclusive or` if the `api_key` is set or if  `client_id`is set. This parameters should be placed in the `url` according to the new google maps documentation.
https://developers.google.com/maps/documentation/static-maps/get-api-key?hl=en_US#dig-sig-key